### PR TITLE
feat: Implémenter l'affectation des élèves aux salles

### DIFF
--- a/apps/server/prisma/schema/schema.prisma
+++ b/apps/server/prisma/schema/schema.prisma
@@ -26,6 +26,7 @@ model Student {
   createdAt      DateTime   @default(now())
   updatedAt      DateTime   @updatedAt
   classeId       String?    @db.ObjectId
+  salleCode      String?
   classe         Classe?    @relation(fields: [classeId], references: [id])
   userId         String?    @db.ObjectId
   user           User?      @relation(fields: [userId], references: [id], name: "UserStudents")

--- a/apps/server/src/controllers/academics/assignmentController.ts
+++ b/apps/server/src/controllers/academics/assignmentController.ts
@@ -1,0 +1,200 @@
+import type { Request, Response } from 'express';
+import prisma from '../../../prisma';
+
+// NOTE: This controller is written with the assumption that `npx prisma generate`
+// has been run successfully after adding `salleCode: String?` to the Student model.
+// The code may show type errors in an environment where the Prisma client is not updated.
+
+/**
+ * Récupère les salles disponibles pour une classe logique.
+ * Une "classe logique" (ex: "1ère CG") est identifiée par son nom.
+ * Les "salles" sont des enregistrements `Classe` qui partagent ce nom mais ont un champ `salle` défini.
+ */
+export const getSallesForClasse = async (req: Request, res: Response) => {
+  try {
+    const { classeId } = req.params;
+
+    // 1. Trouver la classe logique pour obtenir son nom.
+    const logicalClasse = await prisma.classe.findUnique({
+      where: { id: classeId },
+    });
+
+    if (!logicalClasse) {
+      return res.status(404).json({ success: false, message: 'Classe logique non trouvée.' });
+    }
+
+    // 2. Trouver toutes les classes (salles) qui partagent le même nom et année scolaire,
+    //    mais qui ont une salle définie.
+    const salles = await prisma.classe.findMany({
+      where: {
+        nom: logicalClasse.nom,
+        anneeScolaire: logicalClasse.anneeScolaire,
+        salle: {
+          not: null,
+        },
+      },
+      select: {
+        id: true,
+        salle: true,
+        description: true,
+      },
+      orderBy: {
+        salle: 'asc',
+      },
+    });
+
+    res.status(200).json({ success: true, data: salles });
+  } catch (error) {
+    console.error('[GET /classes/:classeId/salles] Erreur:', error);
+    res.status(500).json({ success: false, message: 'Erreur serveur.' });
+  }
+};
+
+/**
+ * Récupère les élèves d'une classe logique, avec une option pour filtrer
+ * ceux qui n'ont pas encore de salle assignée.
+ */
+export const getStudentsForClasse = async (req: Request, res: Response) => {
+  try {
+    const { classeId } = req.params;
+    const { unassigned } = req.query; // 'true' or 'false'
+
+    const whereClause: any = {
+      classeId: classeId,
+      isActive: true,
+    };
+
+    // Le champ `salleCode` est la nouvelle propriété du modèle Student.
+    if (unassigned === 'true') {
+      whereClause.salleCode = null;
+    }
+
+    const students = await prisma.student.findMany({
+      where: whereClause,
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        matricule: true,
+        salleCode: true, // On inclut le nouveau champ
+      },
+      orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
+    });
+
+    res.status(200).json({ success: true, data: students });
+  } catch (error) {
+    console.error('[GET /classes/:classeId/students] Erreur:', error);
+    res.status(500).json({ success: false, message: 'Erreur serveur.' });
+  }
+};
+
+/**
+ * Affecte une liste d'élèves à une salle spécifique.
+ */
+export const assignStudentsToSalle = async (req: Request, res: Response) => {
+  try {
+    const { classeId } = req.params;
+    const { studentIds, salleCode } = req.body;
+
+    if (!studentIds || !Array.isArray(studentIds) || studentIds.length === 0 || !salleCode) {
+      return res.status(400).json({ success: false, message: 'Les champs `studentIds` (tableau) et `salleCode` sont requis.' });
+    }
+
+    // --- Validation ---
+    // 1. Valider que la salle de destination existe et appartient à la classe logique.
+    const logicalClasse = await prisma.classe.findUnique({ where: { id: classeId } });
+    if (!logicalClasse) {
+      return res.status(404).json({ success: false, message: 'Classe logique non trouvée.' });
+    }
+
+    const targetSalle = await prisma.classe.findFirst({
+      where: {
+        nom: logicalClasse.nom,
+        anneeScolaire: logicalClasse.anneeScolaire,
+        salle: salleCode,
+      },
+    });
+
+    if (!targetSalle) {
+      return res.status(400).json({ success: false, message: `La salle '${salleCode}' n'appartient pas à cette classe.` });
+    }
+
+    // 2. Valider que tous les élèves appartiennent bien à la classe logique.
+    const students = await prisma.student.findMany({
+      where: { id: { in: studentIds } },
+      select: { id: true, classeId: true },
+    });
+
+    const invalidStudents = students.filter(s => s.classeId !== classeId);
+    if (invalidStudents.length > 0) {
+      return res.status(400).json({
+        success: false,
+        message: 'Certains élèves n\'appartiennent pas à la classe spécifiée.',
+        invalidStudentIds: invalidStudents.map(s => s.id),
+      });
+    }
+
+    if(students.length !== studentIds.length){
+       return res.status(404).json({ success: false, message: 'Certains élèves n\'ont pas été trouvés.' });
+    }
+
+    // --- Mise à jour ---
+    const updateResult = await prisma.student.updateMany({
+      where: {
+        id: { in: studentIds },
+        classeId: classeId, // Double sécurité
+      },
+      data: {
+        salleCode: salleCode,
+      },
+    });
+
+    res.status(200).json({ success: true, message: `${updateResult.count} élève(s) affecté(s) à la salle ${salleCode}.` });
+  } catch (error) {
+    console.error('[POST /classes/:classeId/assign-students] Erreur:', error);
+    res.status(500).json({ success: false, message: 'Erreur serveur.' });
+  }
+};
+
+/**
+ * Désaffecte une liste d'élèves de leur salle.
+ */
+export const unassignStudentsFromSalle = async (req: Request, res: Response) => {
+  try {
+    const { classeId } = req.params;
+    const { studentIds } = req.body;
+
+    if (!studentIds || !Array.isArray(studentIds) || studentIds.length === 0) {
+      return res.status(400).json({ success: false, message: 'Le champ `studentIds` (tableau) est requis.' });
+    }
+
+    // Optionnel : Valider que les élèves appartiennent bien à la classe.
+    const students = await prisma.student.findMany({
+        where: { id: { in: studentIds }, classeId: classeId },
+        select: { id: true },
+    });
+
+    if (students.length !== studentIds.length) {
+        return res.status(400).json({
+            success: false,
+            message: 'Certains élèves n\'appartiennent pas à cette classe ou n\'ont pas été trouvés.',
+        });
+    }
+
+    // --- Mise à jour ---
+    const updateResult = await prisma.student.updateMany({
+      where: {
+        id: { in: studentIds },
+        classeId: classeId,
+      },
+      data: {
+        salleCode: null,
+      },
+    });
+
+    res.status(200).json({ success: true, message: `${updateResult.count} élève(s) désaffecté(s).` });
+  } catch (error) {
+    console.error('[POST /classes/:classeId/unassign-students] Erreur:', error);
+    res.status(500).json({ success: false, message: 'Erreur serveur.' });
+  }
+};

--- a/apps/server/src/routes/academics/academics.routes.ts
+++ b/apps/server/src/routes/academics/academics.routes.ts
@@ -54,6 +54,7 @@ import {
 
 import elevesRoutes from './eleves.routes';
 import bulletinsRoutes from './bulletins.routes';
+import assignmentRoutes from './assignment.routes';
 
 const router = express.Router();
 
@@ -103,5 +104,6 @@ router.put('/annees/:id/setCurrent', setCurrentAnneeScolaire);
 
 router.use('/eleves', elevesRoutes);
 router.use('/bulletins', bulletinsRoutes);
+router.use('/assignment', assignmentRoutes);
 
 export default router; 

--- a/apps/server/src/routes/academics/assignment.routes.ts
+++ b/apps/server/src/routes/academics/assignment.routes.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import {
+  getSallesForClasse,
+  getStudentsForClasse,
+  assignStudentsToSalle,
+  unassignStudentsFromSalle,
+} from '../../controllers/academics/assignmentController';
+import { authMiddleware } from '../../middleware/auth';
+
+const router = Router();
+
+// Toutes les routes ici nécessitent une authentification
+router.use(authMiddleware);
+
+/**
+ * @route GET /api/academics/assignment/classes/:classeId/salles
+ * @description Récupère la liste des salles disponibles pour une classe logique.
+ * @access Privé
+ */
+router.get('/classes/:classeId/salles', getSallesForClasse);
+
+/**
+ * @route GET /api/academics/assignment/classes/:classeId/students
+ * @description Récupère les élèves d'une classe, avec option pour filtrer les non-affectés.
+ * @access Privé
+ */
+router.get('/classes/:classeId/students', getStudentsForClasse);
+
+/**
+ * @route POST /api/academics/assignment/classes/:classeId/assign-students
+ * @description Affecte en masse des élèves à une salle spécifique.
+ * @access Privé
+ */
+router.post('/classes/:classeId/assign-students', assignStudentsToSalle);
+
+/**
+ * @route POST /api/academics/assignment/classes/:classeId/unassign-students
+ * @description Désaffecte en masse des élèves d'une salle.
+ * @access Privé
+ */
+router.post('/classes/:classeId/unassign-students', unassignStudentsFromSalle);
+
+export default router;

--- a/apps/web/src/app/admin/classes/assignment/page.tsx
+++ b/apps/web/src/app/admin/classes/assignment/page.tsx
@@ -1,529 +1,277 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from 'sonner';
-import { 
-  Users, 
-  Plus, 
-  Search, 
-  AlertTriangle, 
-  CheckCircle, 
-  User, 
-  School, 
-  UserPlus,
-  Settings,
-  Eye,
-  Trash2
-} from 'lucide-react';
-import { StudentAssignmentDialog } from '@/components/classes/student-assignment-dialog';
-import { ClassManagementCard } from '@/components/classes/class-management-card';
-import { StudentListByClass } from '@/components/classes/student-list-by-class';
-import { ClassStatsCard } from '@/components/classes/class-stats-card';
-import { API_URL, getAuthHeaders } from '@/config/api';
-
-interface Class {
-  id: string;
-  nom: string;
-  salle?: string;
-  section?: { nom: string };
-  option?: { nom: string };
-  anneeScolaire: string;
-  capaciteMaximale: number;
-  description?: string;
-  studentsCount: number;
-  availableSpots: number;
-  isAtCapacity: boolean;
-  capacityPercentage: number;
-}
-
-interface Student {
-  id: string;
-  firstName: string;
-  lastName: string;
-  matricule: string;
-  classe?: {
-    id: string;
-    nom: string;
-  };
-  parentPhone: string;
-}
-
-interface ClassStats {
-  totalClasses: number;
-  totalCapacity: number;
-  totalStudents: number;
-  availableSpots: number;
-  occupancyPercentage: number;
-}
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Checkbox } from '@/components/ui/checkbox';
+import { School, User, ArrowRight, Trash2, Loader2 } from 'lucide-react';
+import {
+  getSallesByClass,
+  getStudentsByClass,
+  assignStudentsToSalle,
+  unassignStudentsFromSalle,
+  Salle,
+  StudentForAssignment,
+} from '@/services/assignment';
+import { getAllClasses, Classe } from '@/services/academics';
 
 const ClassAssignmentPage = () => {
-  const [classes, setClasses] = useState<Class[]>([]);
-  const [students, setStudents] = useState<Student[]>([]);
-  const [stats, setStats] = useState<ClassStats | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedAnneeScolaire, setSelectedAnneeScolaire] = useState('');
-  const [selectedSection, setSelectedSection] = useState('all');
-  const [selectedClass, setSelectedClass] = useState<Class | null>(null);
-  const [assignmentDialogOpen, setAssignmentDialogOpen] = useState(false);
-  const [unassignedStudentsOnly, setUnassignedStudentsOnly] = useState(false);
+  // State
+  const [logicalClasses, setLogicalClasses] = useState<Classe[]>([]);
+  const [students, setStudents] = useState<StudentForAssignment[]>([]);
+  const [salles, setSalles] = useState<Salle[]>([]);
 
-  // États pour la gestion des années scolaires, sections, etc.
-  const [anneesScolaires, setAnneesScolaires] = useState<string[]>([]);
-  const [sections, setSections] = useState<Array<{id: string, nom: string}>>([]);
+  const [selectedLogicalClassId, setSelectedLogicalClassId] = useState<string | null>(null);
+  const [selectedSalleCode, setSelectedSalleCode] = useState<string | null>(null);
+  const [selectedStudentIds, setSelectedStudentIds] = useState<string[]>([]);
 
-  const fetchClasses = async () => {
+  const [loading, setLoading] = useState({
+    classes: true,
+    students: false,
+    salles: false,
+    assignment: false,
+  });
+
+  // Fetch initial logical classes (classes without a specific 'salle')
+  const fetchLogicalClasses = useCallback(async () => {
+    setLoading(prev => ({ ...prev, classes: true }));
     try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      const params = new URLSearchParams();
-      if (selectedAnneeScolaire) params.append('anneeScolaire', selectedAnneeScolaire);
-      if (selectedSection && selectedSection !== 'all') params.append('sectionId', selectedSection);
-      if (searchTerm) params.append('search', searchTerm);
-      
-      const response = await fetch(`${API_URL}/academics/classes?${params.toString()}`, {
-        headers,
-        credentials: 'include',
-      });
-      const data = await response.json();
-      
-      if (data.success) {
-        setClasses(data.data);
-      } else {
-        toast.error('Erreur lors du chargement des classes');
-      }
+      // Fetch all classes and filter on the frontend for "logical" ones (those without a salle)
+      const all_classes = await getAllClasses();
+      const logical = all_classes.filter(c => !c.salle);
+      setLogicalClasses(logical);
     } catch (error) {
-      toast.error('Erreur de connexion');
+      toast.error('Erreur lors du chargement des classes logiques.');
+    } finally {
+      setLoading(prev => ({ ...prev, classes: false }));
     }
-  };
-
-  const fetchStudents = async () => {
-    try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      const params = new URLSearchParams();
-      if (searchTerm) params.append('search', searchTerm);
-      if (unassignedStudentsOnly) params.append('classeId', 'null');
-      
-      const response = await fetch(`${API_URL}/academics/eleves?${params.toString()}`, {
-        headers,
-        credentials: 'include',
-      });
-      const data = await response.json();
-      
-      if (data.success) {
-        setStudents(data.data);
-      } else {
-        toast.error('Erreur lors du chargement des élèves');
-      }
-    } catch (error) {
-      toast.error('Erreur de connexion');
-    }
-  };
-
-  const fetchStats = async () => {
-    try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      const params = new URLSearchParams();
-      if (selectedAnneeScolaire) params.append('anneeScolaire', selectedAnneeScolaire);
-      
-      let response = await fetch(`${API_URL}/academics/classes/stats?${params.toString()}`, {
-        headers,
-        credentials: 'include',
-      });
-
-      // Fallback: si erreur serveur (ex: année inexistante), retenter sans filtre d'année
-      if (!response.ok) {
-        response = await fetch(`${API_URL}/academics/classes/stats`, {
-          headers,
-          credentials: 'include',
-        });
-      }
-
-      const data = await response.json();
-      
-      if (data.success) {
-        setStats(data.data);
-      }
-    } catch (error) {
-      console.error('Erreur lors du chargement des statistiques:', error);
-    }
-  };
-
-  const fetchMetadata = async () => {
-    try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      // Récupérer les années scolaires
-      const anneesResponse = await fetch(`${API_URL}/academics/annees`, {
-        headers,
-        credentials: 'include',
-      });
-      const anneesData = await anneesResponse.json();
-      if (anneesData.success) {
-        const years = anneesData.data.map((a: any) => a.nom);
-        setAnneesScolaires(years);
-        
-        // Définir l'année courante par défaut
-        const currentYear = anneesData.data.find((a: any) => a.actuelle);
-        if (currentYear) {
-          setSelectedAnneeScolaire(currentYear.nom);
-        }
-      }
-
-      // Récupérer les sections
-      const sectionsResponse = await fetch(`${API_URL}/academics/sections`, {
-        headers,
-        credentials: 'include',
-      });
-      const sectionsData = await sectionsResponse.json();
-      if (sectionsData.success) {
-        setSections(sectionsData.data);
-      }
-    } catch (error) {
-      console.error('Erreur lors du chargement des métadonnées:', error);
-    }
-  };
-
-  const handleAssignStudent = async (studentId: string, classId: string, forceAssignment = false) => {
-    try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      const response = await fetch(`${API_URL}/academics/eleves/add-to-classe`, {
-        method: 'POST',
-        headers,
-        credentials: 'include',
-        body: JSON.stringify({
-          eleveId: studentId,
-          classeId: classId,
-          forceAssignment
-        }),
-      });
-
-      const data = await response.json();
-      
-      if (data.success) {
-        toast.success(data.message);
-        await Promise.all([fetchClasses(), fetchStudents(), fetchStats()]);
-        setAssignmentDialogOpen(false);
-      } else if (response.status === 409) {
-        // Conflits détectés
-        const confirmForce = confirm(
-          `Conflits détectés:\n${data.conflicts.join('\n')}\n\nForcer l'affectation ?`
-        );
-        
-        if (confirmForce) {
-          await handleAssignStudent(studentId, classId, true);
-        }
-      } else {
-        toast.error(data.message || 'Erreur lors de l\'affectation');
-      }
-    } catch (error) {
-      toast.error('Erreur de connexion');
-    }
-  };
-
-  const handleRemoveStudent = async (classId: string, studentId: string) => {
-    if (!confirm('Retirer cet élève de la classe ?')) return;
-    
-    try {
-      const headers = getAuthHeaders();
-      if (!headers.Authorization) return;
-      const response = await fetch(`${API_URL}/academics/classes/${classId}/students/${studentId}`, {
-        method: 'DELETE',
-        headers,
-        credentials: 'include',
-      });
-
-      const data = await response.json();
-      
-      if (data.success) {
-        toast.success(data.message);
-        await Promise.all([fetchClasses(), fetchStudents(), fetchStats()]);
-      } else {
-        toast.error(data.message || 'Erreur lors du retrait');
-      }
-    } catch (error) {
-      toast.error('Erreur de connexion');
-    }
-  };
-
-  useEffect(() => {
-    fetchMetadata();
   }, []);
 
   useEffect(() => {
-    if (selectedAnneeScolaire) {
-      setLoading(true);
-      Promise.all([fetchClasses(), fetchStudents(), fetchStats()])
-        .finally(() => setLoading(false));
-    }
-  }, [selectedAnneeScolaire, selectedSection, searchTerm, unassignedStudentsOnly]);
+    fetchLogicalClasses();
+  }, [fetchLogicalClasses]);
 
-  const getCapacityBadgeVariant = (percentage: number) => {
-    if (percentage >= 100) return 'destructive';
-    if (percentage >= 80) return 'outline';
-    return 'secondary';
+  // Fetch students and salles when a logical class is selected
+  useEffect(() => {
+    if (!selectedLogicalClassId) {
+      setStudents([]);
+      setSalles([]);
+      return;
+    }
+
+    const fetchDataForClass = async () => {
+      setLoading(prev => ({ ...prev, students: true, salles: true }));
+      try {
+        const [studentsData, sallesData] = await Promise.all([
+          getStudentsByClass(selectedLogicalClassId),
+          getSallesByClass(selectedLogicalClassId),
+        ]);
+        setStudents(studentsData);
+        setSalles(sallesData);
+      } catch (error) {
+        toast.error("Erreur lors du chargement des élèves ou des salles.");
+      } finally {
+        setLoading(prev => ({ ...prev, students: false, salles: false }));
+      }
+    };
+
+    fetchDataForClass();
+    setSelectedStudentIds([]);
+    setSelectedSalleCode(null);
+  }, [selectedLogicalClassId]);
+
+  const handleAssign = async () => {
+    if (!selectedLogicalClassId || !selectedSalleCode || selectedStudentIds.length === 0) {
+      toast.warning('Veuillez sélectionner une classe, une salle et au moins un élève.');
+      return;
+    }
+    setLoading(prev => ({ ...prev, assignment: true }));
+    try {
+      const payload = { studentIds: selectedStudentIds, salleCode: selectedSalleCode };
+      const result = await assignStudentsToSalle(selectedLogicalClassId, payload);
+      toast.success(result.message);
+      // Refresh student list
+      const updatedStudents = await getStudentsByClass(selectedLogicalClassId);
+      setStudents(updatedStudents);
+      setSelectedStudentIds([]);
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || "Erreur lors de l'affectation.");
+    } finally {
+      setLoading(prev => ({ ...prev, assignment: false }));
+    }
   };
 
-  const filteredStudents = students.filter(student => 
-    unassignedStudentsOnly ? !student.classe : true
-  );
+  const handleUnassign = async () => {
+    if (!selectedLogicalClassId || selectedStudentIds.length === 0) {
+       toast.warning('Veuillez sélectionner une classe et au moins un élève.');
+      return;
+    }
+    setLoading(prev => ({ ...prev, assignment: true }));
+    try {
+      const payload = { studentIds: selectedStudentIds };
+      const result = await unassignStudentsFromSalle(selectedLogicalClassId, payload);
+      toast.success(result.message);
+      // Refresh student list
+      const updatedStudents = await getStudentsByClass(selectedLogicalClassId);
+      setStudents(updatedStudents);
+      setSelectedStudentIds([]);
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || "Erreur lors de la désaffectation.");
+    } finally {
+      setLoading(prev => ({ ...prev, assignment: false }));
+    }
+  };
+
+  const toggleSelectAll = (checked: boolean) => {
+    setSelectedStudentIds(checked ? students.map(s => s.id) : []);
+  };
+
+  const toggleStudentSelection = (studentId: string, checked: boolean) => {
+    setSelectedStudentIds(prev =>
+      checked ? [...prev, studentId] : prev.filter(id => id !== studentId)
+    );
+  };
+
+  const selectedClass = useMemo(() => {
+    return logicalClasses.find(c => c.id === selectedLogicalClassId);
+  }, [selectedLogicalClassId, logicalClasses]);
 
   return (
     <div className="space-y-6 p-6">
-      {/* En-tête */}
-      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+      <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold">Affectation des élèves</h1>
+          <h1 className="text-3xl font-bold">Affectation aux Salles</h1>
           <p className="text-muted-foreground">
-            Gérez l'affectation des élèves dans les salles de classe
+            Assignez des élèves à une salle au sein de leur classe.
           </p>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            onClick={() => setAssignmentDialogOpen(true)}
-            className="flex items-center gap-2"
-          >
-            <UserPlus className="h-4 w-4" />
-            Affecter un élève
-          </Button>
         </div>
       </div>
 
-      {/* Statistiques */}
-      {stats && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <ClassStatsCard
-            title="Classes totales"
-            value={stats.totalClasses}
-            icon={School}
-            variant="default"
-          />
-          <ClassStatsCard
-            title="Capacité totale"
-            value={stats.totalCapacity}
-            icon={Users}
-            variant="default"
-          />
-          <ClassStatsCard
-            title="Élèves inscrits"
-            value={stats.totalStudents}
-            icon={User}
-            variant="default"
-          />
-          <ClassStatsCard
-            title="Taux d'occupation"
-            value={`${stats.occupancyPercentage}%`}
-            icon={CheckCircle}
-            variant={stats.occupancyPercentage > 90 ? "destructive" : "default"}
-          />
-        </div>
-      )}
-
-      {/* Filtres */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Filtres
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            <div>
-              <label className="text-sm font-medium mb-2 block">Recherche</label>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Rechercher..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-9"
-                />
-              </div>
-            </div>
-            
-            <div>
-              <label className="text-sm font-medium mb-2 block">Année scolaire</label>
-              <Select value={selectedAnneeScolaire} onValueChange={setSelectedAnneeScolaire}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Sélectionner l'année" />
-                </SelectTrigger>
-                <SelectContent>
-                  {anneesScolaires.map((annee) => (
-                    <SelectItem key={annee} value={annee}>
-                      {annee}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div>
-              <label className="text-sm font-medium mb-2 block">Section</label>
-              <Select value={selectedSection} onValueChange={setSelectedSection}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Toutes les sections" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Toutes les sections</SelectItem>
-                  {sections.map((section) => (
-                    <SelectItem key={section.id} value={section.id}>
-                      {section.nom}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="flex items-end">
-              <Button
-                variant={unassignedStudentsOnly ? "default" : "outline"}
-                onClick={() => setUnassignedStudentsOnly(!unassignedStudentsOnly)}
-                className="w-full"
-              >
-                {unassignedStudentsOnly ? "Tous les élèves" : "Élèves non affectés"}
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Contenu principal */}
-      <Tabs defaultValue="classes" className="space-y-4">
-        <TabsList>
-          <TabsTrigger value="classes">Vue par classes</TabsTrigger>
-          <TabsTrigger value="students">Vue par élèves</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="classes" className="space-y-4">
-          {loading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {[...Array(6)].map((_, i) => (
-                <Card key={i} className="animate-pulse">
-                  <CardContent className="p-6">
-                    <div className="h-20 bg-gray-200 rounded"></div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {classes.map((classe) => (
-                <ClassManagementCard
-                  key={classe.id}
-                  class={classe}
-                  onViewStudents={() => setSelectedClass(classe)}
-                  onAssignStudent={() => {
-                    setSelectedClass(classe);
-                    setAssignmentDialogOpen(true);
-                  }}
-                />
-              ))}
-            </div>
-          )}
-        </TabsContent>
-
-        <TabsContent value="students" className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Colonne de sélection */}
+        <div className="lg:col-span-1 space-y-4">
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center justify-between">
-                <span>Liste des élèves</span>
-                <Badge variant="secondary">
-                  {filteredStudents.length} élève{filteredStudents.length > 1 ? 's' : ''}
-                </Badge>
+              <CardTitle className="flex items-center gap-2">
+                <School className="h-5 w-5" />
+                1. Choisissez une Classe
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <div className="grid gap-4">
-                {filteredStudents.map((student) => (
-                  <div
-                    key={student.id}
-                    className="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50"
-                  >
-                    <div className="flex items-center gap-4">
-                      <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
-                        <User className="h-5 w-5 text-blue-600" />
-                      </div>
-                      <div>
-                        <p className="font-medium">
-                          {student.firstName} {student.lastName}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {student.matricule}
-                        </p>
-                      </div>
-                    </div>
-                    
-                    <div className="flex items-center gap-4">
-                      {student.classe ? (
-                        <Badge variant="secondary">
-                          {student.classe.nom}
-                        </Badge>
-                      ) : (
-                        <Badge variant="outline">
-                          Non affecté
-                        </Badge>
-                      )}
-                      
-                      <div className="flex gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => {
-                            // Implémenter la vue détaillée de l'élève
-                            toast.info('Vue détaillée à implémenter');
-                          }}
-                        >
-                          <Eye className="h-4 w-4" />
-                        </Button>
-                        
-                        {!student.classe && (
-                          <Button
-                            size="sm"
-                            onClick={() => setAssignmentDialogOpen(true)}
-                          >
-                            <Plus className="h-4 w-4" />
-                            Affecter
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <Select onValueChange={setSelectedLogicalClassId} value={selectedLogicalClassId || ''}>
+                <SelectTrigger disabled={loading.classes}>
+                  <SelectValue placeholder={loading.classes ? "Chargement..." : "Sélectionner une classe"} />
+                </SelectTrigger>
+                <SelectContent>
+                  {logicalClasses.map(cls => (
+                    <SelectItem key={cls.id} value={cls.id}>
+                      {cls.nom}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </CardContent>
           </Card>
-        </TabsContent>
-      </Tabs>
 
-      {/* Dialog d'affectation */}
-      <StudentAssignmentDialog
-        open={assignmentDialogOpen}
-        onOpenChange={setAssignmentDialogOpen}
-        classes={classes}
-        students={filteredStudents}
-        selectedClass={selectedClass}
-        onAssign={handleAssignStudent}
-      />
+          {selectedLogicalClassId && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <ArrowRight className="h-5 w-5" />
+                  2. Choisissez une Salle
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Select onValueChange={setSelectedSalleCode} value={selectedSalleCode || ''}>
+                  <SelectTrigger disabled={loading.salles}>
+                    <SelectValue placeholder={loading.salles ? "Chargement..." : "Sélectionner une salle"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {salles.map(salle => (
+                      <SelectItem key={salle.salle} value={salle.salle}>
+                        Salle {salle.salle}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                 <div className="mt-4 flex flex-col space-y-2">
+                   <Button onClick={handleAssign} disabled={loading.assignment || !selectedSalleCode || selectedStudentIds.length === 0}>
+                     {loading.assignment && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                     Affecter ({selectedStudentIds.length}) à cette salle
+                   </Button>
+                   <Button onClick={handleUnassign} variant="outline" disabled={loading.assignment || selectedStudentIds.length === 0}>
+                     <Trash2 className="mr-2 h-4 w-4" />
+                     Désaffecter la sélection ({selectedStudentIds.length})
+                   </Button>
+                 </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
 
-      {/* Dialog de vue des élèves d'une classe */}
-      {selectedClass && (
-        <StudentListByClass
-          class={selectedClass}
-          open={!!selectedClass}
-          onOpenChange={() => setSelectedClass(null)}
-          onRemoveStudent={handleRemoveStudent}
-        />
-      )}
+        {/* Colonne de la liste des élèves */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                <div className='flex items-center gap-2'>
+                  <User className="h-5 w-5" />
+                  <span>Élèves de la classe {selectedClass?.nom || '...'}</span>
+                </div>
+                <Badge variant="secondary">{students.length} élèves</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {loading.students ? (
+                 <div className="flex justify-center items-center h-48">
+                    <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+                 </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[50px]">
+                        <Checkbox
+                          checked={selectedStudentIds.length === students.length && students.length > 0}
+                          onCheckedChange={toggleSelectAll}
+                        />
+                      </TableHead>
+                      <TableHead>Nom</TableHead>
+                      <TableHead>Matricule</TableHead>
+                      <TableHead className="text-right">Salle Actuelle</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {students.map(student => (
+                      <TableRow key={student.id}>
+                        <TableCell>
+                          <Checkbox
+                            checked={selectedStudentIds.includes(student.id)}
+                            onCheckedChange={(checked) => toggleStudentSelection(student.id, !!checked)}
+                          />
+                        </TableCell>
+                        <TableCell className="font-medium">{student.firstName} {student.lastName}</TableCell>
+                        <TableCell>{student.matricule}</TableCell>
+                        <TableCell className="text-right">
+                          {student.salleCode ? (
+                            <Badge variant="default">Salle {student.salleCode}</Badge>
+                          ) : (
+                            <Badge variant="outline">Non affecté</Badge>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/services/academics.ts
+++ b/apps/web/src/services/academics.ts
@@ -244,6 +244,7 @@ export const academicsService = {
 };
 
 // Exports individuels pour compatibilité avec les composants existants
+export const getAllClasses = classesService.getAll;
 export const getClasses = classesService.getAll;
 export const getSections = sectionsService.getAll;
 export const getOptions = optionsService.getAll;

--- a/apps/web/src/services/assignment.ts
+++ b/apps/web/src/services/assignment.ts
@@ -1,0 +1,71 @@
+import axiosInstance from '../lib/axiosInstance';
+
+// --- Types / Interfaces ---
+
+export interface Salle {
+  id: string;
+  salle: string;
+  description?: string;
+}
+
+export interface StudentForAssignment {
+  id: string;
+  firstName: string;
+  lastName: string;
+  matricule: string;
+  salleCode: string | null;
+}
+
+export interface AssignPayload {
+  studentIds: string[];
+  salleCode: string;
+}
+
+export interface UnassignPayload {
+  studentIds: string[];
+}
+
+// --- Service Functions ---
+
+/**
+ * Récupère les salles disponibles pour une classe logique donnée.
+ * @param classeId - L'ID de la classe logique.
+ */
+export const getSallesByClass = async (classeId: string): Promise<Salle[]> => {
+  const response = await axiosInstance.get(`/academics/assignment/classes/${classeId}/salles`);
+  return response.data.data;
+};
+
+/**
+ * Récupère les élèves d'une classe logique.
+ * @param classeId - L'ID de la classe logique.
+ * @param unassigned - Si true, ne retourne que les élèves non affectés à une salle.
+ */
+export const getStudentsByClass = async (classeId: string, unassigned = false): Promise<StudentForAssignment[]> => {
+  const params = new URLSearchParams();
+  if (unassigned) {
+    params.append('unassigned', 'true');
+  }
+  const response = await axiosInstance.get(`/academics/assignment/classes/${classeId}/students`, { params });
+  return response.data.data;
+};
+
+/**
+ * Affecte une liste d'élèves à une salle.
+ * @param classeId - L'ID de la classe logique à laquelle les élèves et la salle appartiennent.
+ * @param payload - Les données contenant les IDs des élèves et le code de la salle.
+ */
+export const assignStudentsToSalle = async (classeId: string, payload: AssignPayload): Promise<any> => {
+  const response = await axiosInstance.post(`/academics/assignment/classes/${classeId}/assign-students`, payload);
+  return response.data;
+};
+
+/**
+ * Désaffecte une liste d'élèves de leur salle.
+ * @param classeId - L'ID de la classe logique.
+ * @param payload - Les données contenant les IDs des élèves.
+ */
+export const unassignStudentsFromSalle = async (classeId: string, payload: UnassignPayload): Promise<any> => {
+  const response = await axiosInstance.post(`/academics/assignment/classes/${classeId}/unassign-students`, payload);
+  return response.data;
+};

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [2025-08-17] - Implémentation de l'affectation des élèves aux salles
+
+### 🎯 Objectif
+Permettre l'affectation d'un élève à une salle spécifique (ex: "A", "B") au sein de sa classe logique (ex: "1ère CG"), en s'assurant que l'affectation n'est possible que dans les salles de la bonne classe.
+
+### ✨ Nouvelles fonctionnalités
+
+#### 🗄️ Modèle de données
+- **Ajout du champ `salleCode`** sur le modèle `Student` dans `prisma/schema.prisma` pour stocker la salle assignée.
+
+#### 🔧 Backend (API)
+- **Nouvelles routes** (`apps/server/src/routes/academics/assignment.routes.ts`) dédiées à l'affectation.
+- **Nouveau contrôleur** (`apps/server/src/controllers/academics/assignmentController.ts`) avec la logique métier :
+  - `GET /api/classes/:classeId/salles` : Récupère les salles disponibles pour une classe.
+  - `GET /api/classes/:classeId/students` : Récupère les élèves d'une classe (avec filtre pour les non-affectés).
+  - `POST /api/classes/:classeId/assign-students` : Affecte en masse des élèves à une salle.
+  - `POST /api/classes/:classeId/unassign-students` : Désaffecte en masse des élèves.
+- **Validation Stricte** : Le backend vérifie que les élèves et la salle cible appartiennent bien à la même classe logique avant toute affectation.
+
+#### 🎨 Frontend
+- **Nouveau service API** (`apps/web/src/services/assignment.ts`) utilisant `axiosInstance`.
+- **Refonte complète de la page d'affectation** (`/admin/classes/assignment/page.tsx`):
+  - Workflow en 2 étapes : sélection de la classe, puis sélection des élèves et de la salle.
+  - La liste des salles est filtrée dynamiquement en fonction de la classe choisie.
+  - Tableau des élèves avec cases à cocher pour la sélection multiple.
+  - Affichage du statut d'affectation de chaque élève (ex: "Salle A" ou "Non affecté").
+  - Logique pour affecter/désaffecter en masse les élèves sélectionnés.
+
+### 🛠️ Fichiers créés/modifiés
+- `apps/server/prisma/schema/schema.prisma`
+- `apps/server/src/routes/academics/assignment.routes.ts`
+- `apps/server/src/controllers/academics/assignmentController.ts`
+- `apps/server/src/routes/academics/academics.routes.ts`
+- `apps/web/src/services/assignment.ts`
+- `apps/web/src/app/admin/classes/assignment/page.tsx`
+
+---
+
 ## [2025-01-19] - Développement complet du module "Gestion des bulletins & notes"
 
 ### 🎯 Objectif atteint

--- a/package-lock.json
+++ b/package-lock.json
@@ -3681,6 +3681,8 @@
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
This commit introduces a new feature allowing administrators to assign students to specific classrooms (`salles`) within their logical class.

The implementation follows a two-level hierarchy:
1. A student is associated with a logical class (e.g., "1ère CG").
2. The student can then be assigned to a specific salle (e.g., "A", "B") that belongs to that logical class.

Key changes:
- **Data Model:** The `Student` model in `schema.prisma` is extended with an optional `salleCode` field to store the assignment.
- **Backend:** New API endpoints under `/api/academics/assignment/` are created to manage the assignment process. This includes fetching available salles for a class, fetching students, and assigning/un-assigning them in bulk. Strict validation is added to prevent cross-class assignments.
- **Frontend:** The assignment page at `/admin/classes/assignment` has been completely refactored. It now features a new UI that guides the user through selecting a logical class, which then dynamically loads the corresponding students and available salles for assignment.
- **Services:** A new `assignment.ts` service was added to centralize API calls for the frontend, and `fetch` calls were replaced with `axiosInstance`.